### PR TITLE
Standardize Python version 3.10

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,5 +10,5 @@ lark-parser = "*"
 [dev-packages]
 
 [requires]
-python_version = "3.13"
-python_full_version = "3.13.3"
+python_version = "3.10"
+python_full_version = "3.10.14"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -5,8 +5,8 @@
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_full_version": "3.13.3",
-            "python_version": "3.13"
+            "python_full_version": "3.10.14",
+            "python_version": "3.10"
         },
         "sources": [
             {

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 ```bash
 git clone https://github.com/Bryantad/Sona.git
 cd Sona
-python3 -m venv .venv
+python3.10 -m venv .venv
 source .venv/bin/activate
 pip install -U pip setuptools wheel
 pip install -r requirements.txt   # or `pip install lark-parser`

--- a/ci.yml
+++ b/ci.yml
@@ -8,6 +8,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
-        with: { python-version: "3.9" }
+        with: { python-version: "3.10" }
       - run: pip install -r requirements.txt
       - run: pytest

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -8,19 +8,19 @@
 
    ```bash
    cd sona_core
-   python tools/install.py
+   python3.10 tools/install.py
    ```
 
    For a virtual environment:
 
    ```bash
-   python tools/install.py --venv
+   python3.10 tools/install.py --venv
    source venv/bin/activate  # On Linux/macOS
    ```
 
 3. **Verify installation**:
    ```bash
-   python -m sona.sona_cli -c "print('Hello from Sona!')"
+   python3.10 -m sona.sona_cli -c "print('Hello from Sona!')"
    ```
 
 ## Running Sona Programs
@@ -30,7 +30,7 @@
 Run a Sona file:
 
 ```bash
-python -m sona.sona_cli path/to/file.sona
+python3.10 -m sona.sona_cli path/to/file.sona
 ```
 
 ### Interactive REPL
@@ -38,7 +38,7 @@ python -m sona.sona_cli path/to/file.sona
 Start the interactive REPL:
 
 ```bash
-python -m sona.repl
+python3.10 -m sona.repl
 ```
 
 Type Sona code directly. Press Enter twice to execute.
@@ -117,10 +117,10 @@ Try running the included examples:
 
 ```bash
 # Hello World
-python -m sona.sona_cli examples/hello_world.sona
+python3.10 -m sona.sona_cli examples/hello_world.sona
 
 # Calculator
-python -m sona.sona_cli examples/calculator.sona
+python3.10 -m sona.sona_cli examples/calculator.sona
 
 # More examples in the examples/ directory
 ```
@@ -130,7 +130,7 @@ python -m sona.sona_cli examples/calculator.sona
 Run the test suite:
 
 ```bash
-python tools/run_tests.py
+python3.10 tools/run_tests.py
 ```
 
 ## Getting Help

--- a/docs/version_upgrades/RELEASE_NOTES_v0.5.0.md
+++ b/docs/version_upgrades/RELEASE_NOTES_v0.5.0.md
@@ -67,18 +67,18 @@ sona_core/
 1. **Installation**:
 
    ```bash
-   python tools/install.py
+   python3.10 tools/install.py
    ```
 
 2. **Running Sona programs**:
 
    ```bash
-   python -m sona.sona_cli path/to/program.sona
+   python3.10 -m sona.sona_cli path/to/program.sona
    ```
 
 3. **Running tests**:
    ```bash
-   python tools/run_tests.py
+   python3.10 tools/run_tests.py
    ```
 
 ## Documentation

--- a/docs/version_upgrades/v0.5.0_README.md
+++ b/docs/version_upgrades/v0.5.0_README.md
@@ -22,10 +22,10 @@ This version includes several important improvements:
 
 ```bash
 # Run the comprehensive tests
-python tools/run_tests.py
+python3.10 tools/run_tests.py
 
 # Try out a specific example
-python -m sona.sona_cli examples/hello_world.sona
+python3.10 -m sona.sona_cli examples/hello_world.sona
 ```
 
 ### Documentation


### PR DESCRIPTION
## Summary
- set Python 3.10 in Pipfile and lock file
- use Python 3.10 in CI workflow
- update README quick start
- update quick_start and version upgrade docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sona')*

------
https://chatgpt.com/codex/tasks/task_e_6847b60a7f3883298770bf11bc4b5133