### PR TITLE
Fix install paths and clean up debug notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,20 +167,9 @@ Stars, forks, pull requests, and donations are all welcome.
 
 ## License
 
-MIT License. Sona is free to use, build on, and share.  
+MIT License. Sona is free to use, build on, and share.
 Proudly created by Netcore Solutions LLC, a subsidiary of Waycore Inc.
 
 ```
 
 ---
-
-**Explanation of Fixes:**
-1. **Release Notes**: Merged unique points from both branches, removed duplication/conflict markers.
-2. **Quick Start**: Kept the most recent and complete block, removed extra conflict markers.
-3. **Feature Lists**: Chose consistent bullet style and included all unique features.
-4. **REPL Commands**: Preserved the more detailed/updated list from v0.5.1.
-5. **Support Section**: Combined both branch notes—encouraging both support and general contributions.
-6. **Removed all conflict markers**: All <<<<<<<, =======, >>>>>>> are gone.
-
-Let me know if you need this in a different format, or want a commit message for the fix!
-```

--- a/sona/repl.py
+++ b/sona/repl.py
@@ -94,8 +94,8 @@ def run_repl():
                     # Calculator command - added this in v0.5.1 after users requested it
                     elif cmd.lower() in ["calc", "cal", "calculator"]:
                         print("\n=== Launching Sona Calculator ===")
-                        
-                        # TODO: Maybe we should cache these files for faster loading?
+
+                        # Load the calculator example from the repository
                         base_dir = Path(__file__).parent.parent
                         calc_path = base_dir / "examples" / "calculator.sona"
                         

--- a/sona/stdlib/utils/array/smod.py
+++ b/sona/stdlib/utils/array/smod.py
@@ -76,5 +76,6 @@ class ArrayModule:
 # Create the singleton instance
 array = ArrayModule()
 
-# For debugging
-print("[DEBUG] array module loaded")
+import os
+if os.environ.get("SONA_DEBUG") == "1" and os.environ.get("SONA_MODULE_SILENT") != "1":
+    print("[DEBUG] array module loaded")

--- a/sona/stdlib/utils/math/smod.py
+++ b/sona/stdlib/utils/math/smod.py
@@ -96,4 +96,5 @@ class MathModule:
 # ✅ Export as instance (required by Sona's dynamic loader)
 math = MathModule()
 __all__ = ["math"]
-print("[DEBUG] math module loaded:", math.PI)
+if os.environ.get("SONA_DEBUG") == "1" and os.environ.get("SONA_MODULE_SILENT") != "1":
+    print("[DEBUG] math module loaded:", math.PI)

--- a/sona/stdlib/utils/string/smod.py
+++ b/sona/stdlib/utils/string/smod.py
@@ -61,5 +61,6 @@ class StringModule:
 # Create the singleton instance
 string = StringModule()
 
-# For debugging
-print("[DEBUG] string module loaded")
+import os
+if os.environ.get("SONA_DEBUG") == "1" and os.environ.get("SONA_MODULE_SILENT") != "1":
+    print("[DEBUG] string module loaded")

--- a/tools/install.py
+++ b/tools/install.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# filepath: /Volumes/project usb/WayCore Inc/sona_core/tools/install.py
+# tools/install.py - installation helper for Sona
 # Sona v0.5.0 Installation Helper
 
 """
@@ -96,12 +96,12 @@ def setup_cli_alias():
             print("Unsupported shell. Please manually add the alias to your shell config.")
             return
 
-    # Get absolute path to Sona
-    sona_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-    sona_command = f"python -m sona.sona_cli"
-    
+    # Command to invoke the Sona CLI.  Use a relative path so the alias works
+    # even if the project directory is moved after installation.
+    sona_command = "python -m sona.sona_cli"
+
     # Create alias
-    alias_line = f'\n# Sona Programming Language v0.5.0\nalias sona=\'cd "{sona_path}" && {sona_command}\'\n'
+    alias_line = f'\n# Sona Programming Language v0.5.0\nalias sona="{sona_command}"\n'
     
     try:
         # Check if alias already exists


### PR DESCRIPTION
## Summary
- update install helper to use relative paths
- drop fix explanation from `README`
- remove leftover TODO in REPL calculator code
- gate debug prints in stdlib modules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*
- `pip install -e .` *(fails: could not fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6847b6079b848329bcce39a4a3318772